### PR TITLE
Better multi owner support, optimize owner check

### DIFF
--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
+
 import asyncio
 import contextlib
 import copy
-import discord
 import textwrap
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+import discord
 from discord.ext import commands
-
-from utils.flags import ArgumentParsingError
-from utils.useful import StellaEmbed, print_exception, multiget
-from utils.errors import NotInDpy, BypassError
 from utils.buttons import BaseButton, ViewIterationAuthor
-
+from utils.errors import BypassError, NotInDpy
+from utils.flags import ArgumentParsingError
+from utils.useful import StellaEmbed, multiget, print_exception
 
 if TYPE_CHECKING:
     from main import StellaBot
@@ -112,7 +112,7 @@ class ErrorHandler(commands.Cog):
             await send_del(embed=embed)
 
         elif isinstance(error, commands.CommandOnCooldown):
-            if ctx.author == self.bot.stella:
+            if await self.bot.is_owner(ctx.author):
                 return await ctx.reinvoke()
             await send_del(embed=StellaEmbed.to_error(
                 title="Cooldown Error",

--- a/cogs/myself.py
+++ b/cogs/myself.py
@@ -1,26 +1,30 @@
 from __future__ import annotations
-import discord
-import datetime
-import contextlib
-import time
-import tabulate
+
 import asyncio
-import traceback
+import contextlib
+import datetime
 import io
-import textwrap
 import json
-from typing import Union, Optional, Any, Tuple, Coroutine, Generator, Dict, TYPE_CHECKING, List
+import textwrap
+import time
+import traceback
+from typing import (TYPE_CHECKING, Any, Coroutine, Dict, Generator, List,
+                    Optional, Tuple, Union)
+
+import discord
+import tabulate
 from discord.ext import commands
 from discord.ext.commands import Greedy
-from utils import greedy_parser
-from utils.decorators import event_check, pages
-from utils.useful import call, empty_page_format, print_exception, StellaContext, StellaEmbed, aware_utc
-from utils.buttons import InteractionPages
-from utils.greedy_parser import GreedyParser, Separator, UntilFlag
-from utils.new_converters import ValidCog, IsBot, DatetimeConverter, JumpValidator, CodeblockConverter
+from jishaku.codeblocks import Codeblock, codeblock_converter
 from utils import flags as flg
-from utils import menus
-from jishaku.codeblocks import codeblock_converter, Codeblock
+from utils import greedy_parser, menus
+from utils.buttons import InteractionPages
+from utils.decorators import event_check, pages
+from utils.greedy_parser import GreedyParser, Separator, UntilFlag
+from utils.new_converters import (CodeblockConverter, DatetimeConverter, IsBot,
+                                  JumpValidator, ValidCog)
+from utils.useful import (StellaContext, StellaEmbed, aware_utc, call,
+                          empty_page_format, print_exception)
 
 if TYPE_CHECKING:
     from main import StellaBot
@@ -107,7 +111,7 @@ class Myself(commands.Cog):
         uses = flags["uses"]
 
         def check(ctx: StellaContext) -> bool:
-            return ctx.command.qualified_name == coding[command].qualified_name and self.bot.stella == ctx.author
+            return ctx.command.qualified_name == coding[command].qualified_name and self.bot.sync_is_owner(ctx.author)
 
         await ctx.message.add_reaction("<:next_check:754948796361736213>")
         while c := await self.bot.wait_for("command_completion", check=check):

--- a/main.py
+++ b/main.py
@@ -314,7 +314,7 @@ bot_data = {
     "ipc_port": states.get("IPC_PORT"),
     "ipc_key": states.get("IPC_KEY"),
     "intents": intents,
-    "owner_ids": (591135329117798400, 10859 * 233341 * 10 ** 8 + 3 * 7 * 53 * (223914 ^ 255555)),
+    "owner_ids": (591135329117798400, ),
     "websocket_ip": states.get("WEBSOCKET_IP"),
     "prefix_weights": states.get("PREFIX_WEIGHT"),
     "prefix_derivative": states.get("PREFIX_DERIVATIVE_PATH"),

--- a/main.py
+++ b/main.py
@@ -177,7 +177,7 @@ class StellaBot(commands.Bot):
                 raise exc
 
     def sync_is_owner(self, user: discord.User) -> bool:
-        return user.id in self.user_ids
+        return user.id in self.owner_ids
 
     @property
     def stella(self) -> Optional[discord.User]:

--- a/utils/buttons.py
+++ b/utils/buttons.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
-import discord
-import inspect
+
 import asyncio
 import contextlib
+import inspect
 import time
 from copy import copy
 from functools import partial
+from typing import (TYPE_CHECKING, Any, AsyncGenerator, Callable, Coroutine,
+                    Dict, Iterable, Optional, Tuple, Type, Union)
+
+import discord
 from discord import ui
 from discord.ext import commands
-from typing import Optional, Any, Dict, Iterable, Union, Type, TYPE_CHECKING, Coroutine, Callable, Tuple, AsyncGenerator
 
 from utils.context_managers import UserLock
+from utils.menus import (ListPageInteractionBase, MenuBase,
+                         MenuViewInteractionBase)
 from utils.useful import StellaEmbed
-from utils.menus import ListPageInteractionBase, MenuViewInteractionBase, MenuBase
 
 if TYPE_CHECKING:
     from utils.useful import StellaContext
@@ -85,7 +89,7 @@ class ViewAuthor(BaseView):
         """Only allowing the context author to interact with the view"""
         ctx = self.context
         author = ctx.author
-        if interaction.user == ctx.bot.stella:
+        if await ctx.bot.is_owner(interaction.user):
             return True
         if interaction.user != author:
             bucket = self.cooldown.get_bucket(ctx.message)
@@ -441,7 +445,7 @@ class InteractionPages(BaseView, MenuBase):
         """Only allowing the context author to interact with the view"""
         ctx = self.ctx
         author = ctx.author
-        if interaction.user == ctx.bot.stella:
+        if await ctx.bot.is_owner(interaction.user):
             return True
         if interaction.user != author:
             bucket = self.cooldown.get_bucket(ctx.message)


### PR DESCRIPTION
- set `_stella_id` on bot init instead of doing instance checks for each message event
- use bot.is_owner/bot.sync_is_owner for more consistent owner checks
- stella is kept as a separate owner, so all related logic is unchanged
- import changes because my editor insisted on them. tell me if you want me to undo these
- this is untested because deployment steps are not clear